### PR TITLE
Add list view toggle component

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A modern, React-based todo list application with Atlassian-inspired design. This
   - To Do
   - In Progress
   - Done
+- **Toggleable Views**: Switch between Kanban board and a paginated list view
 - **Task Cards**: Each task includes:
   - Title
   - Description
@@ -57,6 +58,7 @@ The application provides a simple and intuitive interface for managing tasks:
 3. Visual indicators (colored borders) help quickly identify task status
 4. Add unique labels to tasks for better organization and categorization
 5. The responsive layout ensures a great experience on both desktop and mobile devices
+6. Use the view toggle button in the header to switch between board and list layouts
 
 ### Task Labels
 - Each task can have a unique label for better organization

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -39,6 +39,11 @@
   background-color: var(--light-gray);
 }
 
+.toggle-wrapper {
+  text-align: right;
+  margin-bottom: 16px;
+}
+
 .task-container {
   padding: 20px;
 }

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './App.css';
 import TaskList from './components/TaskList';
+import ViewToggle from './components/ViewToggle';
 
 function App() {
   const [viewMode, setViewMode] = useState('kanban');
@@ -45,18 +46,12 @@ function App() {
     <div className="app">
       <header className="app-header">
         <h1>Team '25 todo list</h1>
-        <button 
-          className="view-toggle-btn"
-          onClick={toggleView}
-        >
-          {viewMode === 'kanban' ? 'Switch to List View' : 'Switch to Kanban View'}
-        </button>
+        <ViewToggle viewMode={viewMode} toggleView={toggleView} />
       </header>
       <main>
-        <TaskList viewMode={viewMode} />
+        <TaskList viewMode={viewMode} onToggleView={toggleView} />
       </main>
     </div>
   );
 }
-
 export default App;

--- a/my-app/src/components/TaskList.js
+++ b/my-app/src/components/TaskList.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import ViewToggle from './ViewToggle';
 
-function TaskList({ viewMode }) {
+function TaskList({ viewMode, onToggleView }) {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -184,6 +185,9 @@ function TaskList({ viewMode }) {
 
   return (
     <div className={`task-container ${viewMode}`}>
+      <div className="toggle-wrapper">
+        <ViewToggle viewMode={viewMode} toggleView={onToggleView} />
+      </div>
       {viewMode === 'kanban' ? (
         <div className="task-list">
           <TaskColumn status="To Do" />
@@ -199,5 +203,4 @@ function TaskList({ viewMode }) {
     </div>
   );
 }
-
 export default TaskList;

--- a/my-app/src/components/ViewToggle.js
+++ b/my-app/src/components/ViewToggle.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function ViewToggle({ viewMode, toggleView }) {
+  return (
+    <button className="view-toggle-btn" onClick={toggleView}>
+      {viewMode === 'kanban' ? 'Switch to List View' : 'Switch to Kanban View'}
+    </button>
+  );
+}
+
+export default ViewToggle;


### PR DESCRIPTION
## Summary
- add ViewToggle component with switch button
- allow toggling board and list view from header and board itself
- document view toggle in README

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686e197743cc8331bb282db8068b3c38