### PR TITLE
feat: add dark mode with settings toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+my-app/node_modules/

--- a/my-app/database_setup.sql
+++ b/my-app/database_setup.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS user_preferences (
     id SERIAL PRIMARY KEY,
     user_id VARCHAR(50) NOT NULL UNIQUE,
     view_mode VARCHAR(20) DEFAULT 'kanban',
+    theme VARCHAR(20) DEFAULT 'light',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/my-app/server.js
+++ b/my-app/server.js
@@ -137,8 +137,8 @@ app.get('/api/preferences/:userId', async (req, res, next) => {
     if (result.rows.length === 0) {
       // Create default preferences if none exist
       const defaultResult = await pool.query(
-        'INSERT INTO user_preferences (user_id, view_mode) VALUES ($1, $2) RETURNING *',
-        [userId, 'kanban']
+        'INSERT INTO user_preferences (user_id, view_mode, theme) VALUES ($1, $2, $3) RETURNING *',
+        [userId, 'kanban', 'light']
       );
       return res.json(defaultResult.rows[0]);
     }
@@ -152,11 +152,11 @@ app.get('/api/preferences/:userId', async (req, res, next) => {
 app.put('/api/preferences/:userId', async (req, res, next) => {
   try {
     const { userId } = req.params;
-    const { viewMode } = req.body;
+    const { viewMode, theme } = req.body;
     const result = await pool.query(
-      'INSERT INTO user_preferences (user_id, view_mode) VALUES ($1, $2) ' +
-      'ON CONFLICT (user_id) DO UPDATE SET view_mode = $2 RETURNING *',
-      [userId, viewMode]
+      'INSERT INTO user_preferences (user_id, view_mode, theme) VALUES ($1, $2, $3) ' +
+      'ON CONFLICT (user_id) DO UPDATE SET view_mode = $2, theme = $3 RETURNING *',
+      [userId, viewMode, theme]
     );
     res.json(result.rows[0]);
   } catch (err) {

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -9,6 +9,15 @@
   --yellow: #FFAB00;
 }
 
+body.dark-mode {
+  --primary-blue: #4C9AFF;
+  --secondary-blue: #2684FF;
+  --neutral-gray: #DFE1E6;
+  --light-gray: #1B2638;
+  --green: #57D9A3;
+  --yellow: #FFE380;
+}
+
 .app {
   text-align: center;
   background-color: var(--light-gray);
@@ -24,6 +33,11 @@
   align-items: center;
 }
 
+.header-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .view-toggle-btn {
   background-color: var(--white);
   color: var(--primary-blue);
@@ -37,6 +51,15 @@
 
 .view-toggle-btn:hover {
   background-color: var(--light-gray);
+}
+
+.dark-mode .view-toggle-btn {
+  background-color: var(--primary-blue);
+  color: var(--white);
+}
+
+.dark-mode .view-toggle-btn:hover {
+  background-color: var(--secondary-blue);
 }
 
 .task-container {
@@ -71,12 +94,22 @@
   color: var(--neutral-gray);
 }
 
+.dark-mode .task-list-view .task-status {
+  background-color: #2C3E50;
+  color: var(--neutral-gray);
+}
+
 .task-column {
   background-color: var(--white);
   border-radius: 8px;
   padding: 16px;
   min-width: 300px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+}
+
+.dark-mode .task-column {
+  background-color: #2C3E50;
+  border: 1px solid #1B2638;
 }
 
 .task-column h2 {
@@ -91,6 +124,11 @@
   padding: 12px;
   margin-bottom: 8px;
   text-align: left;
+}
+
+.dark-mode .task-card {
+  background-color: #2C3E50;
+  border: 1px solid #1B2638;
 }
 
 .task-card h3 {
@@ -178,4 +216,43 @@
 .label-input:focus {
   outline: 2px solid var(--secondary-blue);
   border-color: transparent;
+}
+
+.dark-mode .label-input {
+  background-color: #2C3E50;
+  border: 1px solid #1B2638;
+  color: var(--neutral-gray);
+}
+
+.settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-modal {
+  background-color: var(--white);
+  padding: 20px;
+  border-radius: 8px;
+  color: var(--neutral-gray);
+  min-width: 200px;
+  text-align: left;
+}
+
+.dark-mode .settings-modal {
+  background-color: #2C3E50;
+  color: var(--neutral-gray);
+}
+
+.settings-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
 }

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -2,9 +2,12 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './App.css';
 import TaskList from './components/TaskList';
+import Settings from './components/Settings';
 
 function App() {
   const [viewMode, setViewMode] = useState('kanban');
+  const [darkMode, setDarkMode] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const userId = 'default-user'; // In a real app, this would come from authentication
@@ -15,6 +18,7 @@ function App() {
         setLoading(true);
         const response = await axios.get(`http://localhost:3001/api/preferences/${userId}`);
         setViewMode(response.data.view_mode);
+        setDarkMode(response.data.theme === 'dark');
         setError(null);
       } catch (err) {
         setError('Failed to load user preferences');
@@ -31,7 +35,8 @@ function App() {
     const newViewMode = viewMode === 'kanban' ? 'list' : 'kanban';
     try {
       await axios.put(`http://localhost:3001/api/preferences/${userId}`, {
-        viewMode: newViewMode
+        viewMode: newViewMode,
+        theme: darkMode ? 'dark' : 'light'
       });
       setViewMode(newViewMode);
       setError(null);
@@ -41,20 +46,54 @@ function App() {
     }
   };
 
+  const toggleDarkMode = async () => {
+    const newDarkMode = !darkMode;
+    try {
+      await axios.put(`http://localhost:3001/api/preferences/${userId}`, {
+        viewMode,
+        theme: newDarkMode ? 'dark' : 'light'
+      });
+      setDarkMode(newDarkMode);
+      setError(null);
+    } catch (err) {
+      setError('Failed to update theme');
+      console.error('Error updating theme:', err);
+    }
+  };
+
+  useEffect(() => {
+    document.body.classList.toggle('dark-mode', darkMode);
+  }, [darkMode]);
+
   return (
     <div className="app">
       <header className="app-header">
         <h1>Team '25 todo list</h1>
-        <button 
-          className="view-toggle-btn"
-          onClick={toggleView}
-        >
-          {viewMode === 'kanban' ? 'Switch to List View' : 'Switch to Kanban View'}
-        </button>
+        <div className="header-actions">
+          <button
+            className="view-toggle-btn"
+            onClick={toggleView}
+          >
+            {viewMode === 'kanban' ? 'Switch to List View' : 'Switch to Kanban View'}
+          </button>
+          <button
+            className="view-toggle-btn"
+            onClick={() => setShowSettings(true)}
+          >
+            Settings
+          </button>
+        </div>
       </header>
       <main>
         <TaskList viewMode={viewMode} />
       </main>
+      {showSettings && (
+        <Settings
+          darkMode={darkMode}
+          toggleDarkMode={toggleDarkMode}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
     </div>
   );
 }

--- a/my-app/src/components/Settings.js
+++ b/my-app/src/components/Settings.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+function Settings({ darkMode, toggleDarkMode, onClose }) {
+  return (
+    <div className="settings-overlay">
+      <div className="settings-modal">
+        <h2>Settings</h2>
+        <label className="settings-option">
+          <input
+            type="checkbox"
+            checked={darkMode}
+            onChange={toggleDarkMode}
+          />
+          Dark Mode
+        </label>
+        <button className="view-toggle-btn" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add theme field to user preferences API and schema
- implement dark mode styles and settings modal with toggle
- persist user theme preference

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b56cbcd25883319c01f0e003be3766